### PR TITLE
[Refactor/#16] 카테고리 수정사항 반영. 타입 및 라벨 변경

### DIFF
--- a/src/entities/place/model/types.ts
+++ b/src/entities/place/model/types.ts
@@ -5,8 +5,8 @@ export type ChipCategory =
   | 'K_CUBE'
   | 'K_HUB'
   | 'CONVENIENCE_STORE'
-  | 'CAFE_RESTIO'
-  | 'CAFE_1847'
+  | 'CAFE'
+  | 'COPY_ROOM'
   | 'STUDENT_CAFETERIA'
   | 'DORMITORY'
   | 'BANK'
@@ -19,8 +19,8 @@ export const CHIP_LABELS: Record<ChipCategory, string> = {
   K_CUBE: 'K-Cube',
   K_HUB: 'K-Hub',
   CONVENIENCE_STORE: '편의점',
-  CAFE_RESTIO: '레스티오',
-  CAFE_1847: '1847',
+  CAFE: '카페',
+  COPY_ROOM: '복사실',
   STUDENT_CAFETERIA: '학생식당',
   DORMITORY: '기숙사',
   BANK: '은행',


### PR DESCRIPTION
- `ChipCategory` 수정
  - 1847, 레스티오 -> CAFE 로 통일
  - 복사실 : COPY_ROOM 추가
- `CHIP_LABELS` 수정
  - CAFE(카페)로 통일 및 COPY_ROOM(복사실) 추가

close #16 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 장소 카테고리 레이블이 업데이트되었습니다. 기존의 일부 카테고리가 제거되고, 통합된 카페 카테고리 및 새로운 복합기실 카테고리가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->